### PR TITLE
Removed redundant Buttons from Create pages of modules.

### DIFF
--- a/src/popup/views/BankAccounts/create.vue
+++ b/src/popup/views/BankAccounts/create.vue
@@ -9,10 +9,6 @@
           </div>
           <span class="fw-bold h5 ml-2">New</span>
         </div>
-        <div>
-          <VIcon class="c-pointer trash" name="trash" />
-          <VIcon class="c-pointer ml-3" name="cogs" />
-        </div>
       </template>
     </Header>
     <div class="scroll">
@@ -137,10 +133,6 @@ export default {
 </script>
 
 <style lang="scss">
-.trash {
-  color: $color-danger;
-}
-
 .new-logo {
   background-color: $color-gray-400;
   border-radius: 8px;

--- a/src/popup/views/CreditCards/create.vue
+++ b/src/popup/views/CreditCards/create.vue
@@ -9,10 +9,6 @@
           </div>
           <span class="fw-bold h5 ml-2">New</span>
         </div>
-        <div>
-          <VIcon class="c-pointer trash" name="trash" />
-          <VIcon class="c-pointer ml-3" name="cogs" />
-        </div>
       </template>
     </Header>
     <div class="scroll">
@@ -136,10 +132,6 @@ export default {
 </script>
 
 <style lang="scss">
-.trash {
-  color: $color-danger;
-}
-
 .new-logo {
   background-color: $color-gray-400;
   border-radius: 8px;

--- a/src/popup/views/Emails/create.vue
+++ b/src/popup/views/Emails/create.vue
@@ -9,10 +9,6 @@
           </div>
           <span class="fw-bold h5 ml-2">New</span>
         </div>
-        <div>
-          <VIcon class="c-pointer trash" name="trash" />
-          <VIcon class="c-pointer ml-3" name="cogs" />
-        </div>
       </template>
     </Header>
     <div class="scroll">
@@ -103,10 +99,6 @@ export default {
 </script>
 
 <style lang="scss">
-.trash {
-  color: $color-danger;
-}
-
 .new-logo {
   background-color: $color-gray-400;
   border-radius: 8px;

--- a/src/popup/views/Logins/create.vue
+++ b/src/popup/views/Logins/create.vue
@@ -9,10 +9,6 @@
           </div>
           <span class="fw-bold h5 ml-2">New</span>
         </div>
-        <div>
-          <VIcon class="c-pointer trash" name="trash" />
-          <VIcon class="c-pointer ml-3" name="cogs" />
-        </div>
       </template>
     </Header>
     <div class="scroll">
@@ -129,10 +125,6 @@ export default {
 </script>
 
 <style lang="scss">
-.trash {
-  color: $color-danger;
-}
-
 .new-logo {
   background-color: $color-gray-400;
   border-radius: 8px;

--- a/src/popup/views/Notes/create.vue
+++ b/src/popup/views/Notes/create.vue
@@ -9,10 +9,6 @@
           </div>
           <span class="fw-bold h5 ml-2">New</span>
         </div>
-        <div>
-          <VIcon class="c-pointer trash" name="trash" />
-          <VIcon class="c-pointer ml-3" name="cogs" />
-        </div>
       </template>
     </Header>
     <div class="scroll">
@@ -80,10 +76,6 @@ export default {
 </script>
 
 <style lang="scss">
-.trash {
-  color: $color-danger;
-}
-
 .new-logo {
   background-color: $color-gray-400;
   border-radius: 8px;

--- a/src/popup/views/Servers/create.vue
+++ b/src/popup/views/Servers/create.vue
@@ -9,10 +9,6 @@
           </div>
           <span class="fw-bold h5 ml-2">New</span>
         </div>
-        <div>
-          <VIcon class="c-pointer trash" name="trash" />
-          <VIcon class="c-pointer ml-3" name="cogs" />
-        </div>
       </template>
     </Header>
     <div class="scroll">
@@ -215,10 +211,6 @@ export default {
 </script>
 
 <style lang="scss">
-.trash {
-  color: $color-danger;
-}
-
 .new-logo {
   background-color: $color-gray-400;
   border-radius: 8px;


### PR DESCRIPTION
Hi,

I consider that the buttons, which in `Create` pages of Modules is redundant. Because actions buttons like `Trash` or `Settings` shouldn't be in Create Pages. That's why I've removed them. 

Thanks.