### PR TITLE
'Add Button' is fixed in order to look like 'Close Button'.

### DIFF
--- a/src/components/FABButton.vue
+++ b/src/components/FABButton.vue
@@ -73,7 +73,7 @@ export default {
 }
 
 .open {
-  transform: rotate(75deg);
+  transform: rotate(135deg);
 }
 
 .fab {


### PR DESCRIPTION
Hi,
I noticed that the Add Button was rotating 75deg when you click it. I thought that It should need to rotate 135deg (or 45deg) for smooth animation and to look like a Close Button when you click it.